### PR TITLE
fix: Bump cli version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Monta `slack notifier cli action`
+
+Github action for posting a message to Slack.
+
+This is used as part of our builds to post progress messages to Slack.
+
+Most project don't use this directly, but indirectly through the [github-workflows](https://github.com/monta-app/github-workflows)
+
+## Example of Github workflow job
+
+```yaml
+steps:
+- name: Publish progress message to slack
+  uses: monta-app/slack-notifier-cli-action@main
+  id: publish-slack
+  with:
+    github-context: ${{ toJson(github) }}
+    job-type: <job-type>
+    job-status: <job-status>
+    service-name: <service-name>
+    service-emoji: <service-emoji>
+    slack-app-token: <token>
+    slack-channel-id: <channel-id>
+```
+
+See further documentation of options in [action.yml](./action.yml)

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
         fetch-depth: 0
     - name: Download changelog cli
       run: |
-        curl -L -o slack-notifier-cli https://github.com/monta-app/slack-notifier-cli/releases/download/v1.0.9/slack-notifier-cli
+        curl -L -o slack-notifier-cli https://github.com/monta-app/slack-notifier-cli/releases/download/v1.1.0/slack-notifier-cli
         chmod +x ./slack-notifier-cli
       shell: bash
     - name: Run slack notifier cli


### PR DESCRIPTION
AFTER https://github.com/monta-app/slack-notifier-cli/pull/18 and after a release of it