### PR TITLE
fix: argument list too long

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ steps:
   uses: monta-app/slack-notifier-cli-action@main
   id: publish-slack
   with:
-    github-context: ${{ toJson(github) }}
     job-type: <job-type>
     job-status: <job-status>
     service-name: <service-name>

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
         fetch-depth: 0
     - name: Download changelog cli
       run: |
-        curl -L -o slack-notifier-cli https://github.com/monta-app/slack-notifier-cli/releases/download/v1.1.3/slack-notifier-cli
+        curl -L -o slack-notifier-cli https://github.com/monta-app/slack-notifier-cli/releases/download/v1.2.0-alpha.0/slack-notifier-cli
         chmod +x ./slack-notifier-cli
       shell: bash
     - name: Run slack notifier cli

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
         fetch-depth: 0
     - name: Download changelog cli
       run: |
-        curl -L -o slack-notifier-cli https://github.com/monta-app/slack-notifier-cli/releases/download/v1.2.0-alpha.0/slack-notifier-cli
+        curl -L -o slack-notifier-cli https://github.com/monta-app/slack-notifier-cli/releases/download/v1.2.0/slack-notifier-cli
         chmod +x ./slack-notifier-cli
       shell: bash
     - name: Run slack notifier cli

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,6 @@
 name: "Slack Notifier CLI"
 description: "Create a change log based of git commit history"
 inputs:
-  github-context:
-    description: ""
-    required: true
   job-type:
     description: ""
     required: true
@@ -44,7 +41,6 @@ runs:
     - name: Run slack notifier cli
       id: slack-notifier
       env:
-        PUBLISH_SLACK_GITHUB_CONTEXT: ${{ inputs.github-context }}
         PUBLISH_SLACK_JOB_TYPE: ${{ inputs.job-type }}
         PUBLISH_SLACK_JOB_STATUS: ${{ inputs.job-status }}
         PUBLISH_SLACK_SERVICE_NAME: ${{ inputs.service-name }}


### PR DESCRIPTION
Update to slack-notifier-cli v1.2.0 and remove github context pass-on. This relates to https://github.com/monta-app/slack-notifier-cli/pull/43. 