### PR TITLE
chore: update slack-notifier-cli to v1.3.19

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ runs:
         fi
 
         echo "Downloading $BINARY_NAME for architecture $ARCH"
-        curl -L -o slack-notifier-cli https://github.com/monta-app/slack-notifier-cli/releases/download/v1.3.16/$BINARY_NAME
+        curl -L -o slack-notifier-cli https://github.com/monta-app/slack-notifier-cli/releases/download/v1.3.19/$BINARY_NAME
         chmod +x ./slack-notifier-cli
       shell: bash
     - name: Run slack notifier cli


### PR DESCRIPTION
Automatically generated PR to update slack-notifier-cli version.

## Changes
- Update slack-notifier-cli to **v1.3.19**

## Release Notes
See the [slack-notifier-cli v1.3.19 release](https://github.com/monta-app/slack-notifier-cli/releases/tag/v1.3.19) for details.

🤖 Automated by slack-notifier-cli release workflow
_Updated: 2026-04-29 08:34:34 UTC_